### PR TITLE
refactor: reuse supabase client

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
   "author": "GeeJay",
   "license": "MIT",
   "dependencies": {
-    "@supabase/supabase-js": "^2.52.0",
     "jotai": "^2.12.5"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "@supabase/supabase-js": "^2.52.0"
+  },
+  "devDependencies": {
+    "@supabase/supabase-js": "^2.52.0"
   }
 }

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,0 +1,18 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const DEFAULT_SUPABASE_URL = 'https://khppgsehvvlukzfdqbuo.supabase.co';
+export const DEFAULT_SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImtocHBnc2VodnZsdWt6ZmRxYnVvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI2ODU1MzQsImV4cCI6MjA2ODI2MTUzNH0.8Z4VY4HFMm95UgO21c-DnDkbLPN_0mbDBZJPExaghDk';
+
+let _supabase: ReturnType<typeof createClient> | null = null;
+
+export function getSupabase() {
+  if (_supabase) return _supabase;
+  _supabase = createClient(DEFAULT_SUPABASE_URL, DEFAULT_SUPABASE_KEY, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      storageKey: 'feature-flags',
+    },
+  });
+  return _supabase;
+}

--- a/src/useFeatureFlags.ts
+++ b/src/useFeatureFlags.ts
@@ -1,11 +1,9 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { createClient } from '@supabase/supabase-js';
 import { FeatureFlag, featureFlagsAtom } from './store';
 import { useAtom } from 'jotai';
+import { getSupabase, DEFAULT_SUPABASE_URL } from './supabaseClient';
 
-export const DEFAULT_SUPABASE_URL = 'https://khppgsehvvlukzfdqbuo.supabase.co';
-export const DEFAULT_SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImtocHBnc2VodnZsdWt6ZmRxYnVvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI2ODU1MzQsImV4cCI6MjA2ODI2MTUzNH0.8Z4VY4HFMm95UgO21c-DnDkbLPN_0mbDBZJPExaghDk';
 const EDGE_FN_URL = `${DEFAULT_SUPABASE_URL}/functions/v1/get-feature-flags`;
 
 
@@ -40,18 +38,7 @@ export function useFeatureFlags(
       `apiKey provided: ${Boolean(apiKey)}`
     );
   }, [sanitizedEnvironment, apiKey]);
-
-  const supabase = createClient(
-  DEFAULT_SUPABASE_URL,
-  DEFAULT_SUPABASE_KEY,
-  {
-    global: {
-      headers: {
-        Authorization: `Bearer ${DEFAULT_SUPABASE_KEY}`, // 👈 dynamic access token
-      },
-    },
-  }
-);
+  const supabase = getSupabase();
 
   const fetchFlags = async () => {
     setState((prev) => ({ ...prev, loading: true }));


### PR DESCRIPTION
## Summary
- create a singleton Supabase client with session persistence disabled
- refactor hook to reuse the shared client instead of instantiating per render
- move `@supabase/supabase-js` to peer/dev dependencies

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68972e70dcbc832ca02a86b055f62342