### PR TITLE
Add cached feature-flag fallback when Supabase is unavailable

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,86 @@
+export type EnvValue = string | undefined;
+
+declare global {
+  // React Native / Expo dev global
+  // eslint-disable-next-line no-var
+  var __DEV__: boolean | undefined;
+}
+
+type EnvRecord = Record<string, unknown>;
+
+let importMetaEnvGetter: (() => EnvRecord | undefined) | null = null;
+
+function getProcessEnv(): EnvRecord | undefined {
+  if (typeof process === 'undefined' || !process) return undefined;
+  const proc = process as unknown as { env?: EnvRecord };
+  if (!proc.env || typeof proc.env !== 'object') return undefined;
+  return proc.env;
+}
+
+function getImportMetaEnv(): EnvRecord | undefined {
+  if (importMetaEnvGetter) return importMetaEnvGetter();
+
+  try {
+    // Keep import.meta access runtime-safe across CJS/ESM bundlers.
+    const fn = new Function(
+      'return (typeof import.meta !== "undefined" && import.meta && import.meta.env) ? import.meta.env : undefined;'
+    ) as () => EnvRecord | undefined;
+
+    importMetaEnvGetter = fn;
+    return fn();
+  } catch {
+    importMetaEnvGetter = () => undefined;
+    return undefined;
+  }
+}
+
+function toStringValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return undefined;
+}
+
+export function getEnvVar(name: string): EnvValue {
+  const processValue = toStringValue(getProcessEnv()?.[name]);
+  if (processValue !== undefined) return processValue;
+
+  const importMetaValue = toStringValue(getImportMetaEnv()?.[name]);
+  if (importMetaValue !== undefined) return importMetaValue;
+
+  return undefined;
+}
+
+function getNodeEnv(): string {
+  const nodeEnv = getEnvVar('NODE_ENV');
+  if (nodeEnv) return nodeEnv;
+
+  const mode = toStringValue(getImportMetaEnv()?.MODE);
+  if (mode) return mode;
+
+  return 'production';
+}
+
+export function isDevelopment(): boolean {
+  if (getNodeEnv() === 'development') return true;
+
+  const importMetaDev = getImportMetaEnv()?.DEV;
+  if (importMetaDev === true || importMetaDev === 'true' || importMetaDev === 1 || importMetaDev === '1') {
+    return true;
+  }
+
+  if (typeof globalThis !== 'undefined' && (globalThis as typeof globalThis & { __DEV__?: unknown }).__DEV__ === true) {
+    return true;
+  }
+
+  return false;
+}
+
+export function isDebugEnabled(): boolean {
+  const debug = getEnvVar('DEBUG');
+  if (!debug) return false;
+
+  const normalized = debug.toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === '*';
+}

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -10,12 +10,14 @@ declare global {
 
 export const DEFAULT_SUPABASE_URL = 'https://khppgsehvvlukzfdqbuo.supabase.co';
 
+export function getSupabaseUrl(): string {
+  return (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_SUPABASE_URL) || DEFAULT_SUPABASE_URL;
+}
+
 export function getSupabase(): SupabaseClient {
   if (!globalThis[GLOBAL_KEY]) {
     // Prefer env vars; fallback are placeholders (replace in your app env)
-    const url =
-      (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_SUPABASE_URL) ||
-      DEFAULT_SUPABASE_URL;
+    const url = getSupabaseUrl();
     const anon =
       (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_SUPABASE_ANON_KEY) ||
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImtocHBnc2VodnZsdWt6ZmRxYnVvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI2ODU1MzQsImV4cCI6MjA2ODI2MTUzNH0.8Z4VY4HFMm95UgO21c-DnDkbLPN_0mbDBZJPExaghDk';

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,4 +1,5 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { getEnvVar } from './env';
 
 // HMR-safe global singleton to avoid multiple GoTrueClient instances
 const GLOBAL_KEY = '__useff_supabase_singleton__';
@@ -11,7 +12,7 @@ declare global {
 export const DEFAULT_SUPABASE_URL = 'https://khppgsehvvlukzfdqbuo.supabase.co';
 
 export function getSupabaseUrl(): string {
-  return (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_SUPABASE_URL) || DEFAULT_SUPABASE_URL;
+  return getEnvVar('NEXT_PUBLIC_SUPABASE_URL') || getEnvVar('VITE_SUPABASE_URL') || DEFAULT_SUPABASE_URL;
 }
 
 export function getSupabase(): SupabaseClient {
@@ -19,7 +20,8 @@ export function getSupabase(): SupabaseClient {
     // Prefer env vars; fallback are placeholders (replace in your app env)
     const url = getSupabaseUrl();
     const anon =
-      (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_SUPABASE_ANON_KEY) ||
+      getEnvVar('NEXT_PUBLIC_SUPABASE_ANON_KEY') ||
+      getEnvVar('VITE_SUPABASE_ANON_KEY') ||
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImtocHBnc2VodnZsdWt6ZmRxYnVvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI2ODU1MzQsImV4cCI6MjA2ODI2MTUzNH0.8Z4VY4HFMm95UgO21c-DnDkbLPN_0mbDBZJPExaghDk';
 
     globalThis[GLOBAL_KEY] = createClient(url, anon, {

--- a/src/useFeatureFlags.ts
+++ b/src/useFeatureFlags.ts
@@ -2,9 +2,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { FeatureFlag, featureFlagsAtom } from './store';
 import { useAtom } from 'jotai';
-import { getSupabase, DEFAULT_SUPABASE_URL } from './supabaseClient';
-
-const EDGE_FN_URL = `${DEFAULT_SUPABASE_URL}/functions/v1/get-feature-flags`;
+import { getSupabase, getSupabaseUrl } from './supabaseClient';
 const CACHE_KEY_PREFIX = 'use-feature-flags-cache';
 
 
@@ -85,6 +83,7 @@ export function useFeatureFlags(
     );
   }, [sanitizedEnvironment, apiKey]);
   const supabase = getSupabase();
+  const edgeFnUrl = useMemo(() => `${getSupabaseUrl()}/functions/v1/get-feature-flags`, []);
 
   const fetchFlags = async () => {
     setState((prev) => ({ ...prev, loading: true }));
@@ -92,7 +91,7 @@ export function useFeatureFlags(
     console.log('[use-feature-flags] fetching flags for', sanitizedEnvironment);
 
     try {
-      const res = await fetch(EDGE_FN_URL, {
+      const res = await fetch(edgeFnUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/useFeatureFlags.ts
+++ b/src/useFeatureFlags.ts
@@ -5,6 +5,7 @@ import { useAtom } from 'jotai';
 import { getSupabase, DEFAULT_SUPABASE_URL } from './supabaseClient';
 
 const EDGE_FN_URL = `${DEFAULT_SUPABASE_URL}/functions/v1/get-feature-flags`;
+const CACHE_KEY_PREFIX = 'use-feature-flags-cache';
 
 
 
@@ -14,7 +15,52 @@ type FlagState = {
   loading: boolean;
 };
 
+type CachedFlags = {
+  flags: FeatureFlag[];
+  envId: number | null;
+  updatedAt: number;
+};
+
 let initialized = false;
+
+function getCacheKey(environment: string) {
+  return `${CACHE_KEY_PREFIX}:${environment}`;
+}
+
+function getCachedFlags(environment: string): CachedFlags | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+
+  try {
+    const raw = window.localStorage.getItem(getCacheKey(environment));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CachedFlags;
+    if (!Array.isArray(parsed.flags)) return null;
+
+    return {
+      flags: parsed.flags,
+      envId: parsed.envId ?? null,
+      updatedAt: parsed.updatedAt ?? 0,
+    };
+  } catch (error) {
+    console.warn('[use-feature-flags] failed reading cache', error);
+    return null;
+  }
+}
+
+function setCachedFlags(environment: string, flags: FeatureFlag[], envId: number | null) {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+
+  try {
+    const payload: CachedFlags = {
+      flags,
+      envId,
+      updatedAt: Date.now(),
+    };
+    window.localStorage.setItem(getCacheKey(environment), JSON.stringify(payload));
+  } catch (error) {
+    console.warn('[use-feature-flags] failed writing cache', error);
+  }
+}
 
 export function useFeatureFlags(
   passedKey?: string,
@@ -58,6 +104,13 @@ export function useFeatureFlags(
       const json = await res.json();
       if (!res.ok) {
         console.warn('Edge function error:', json?.error || res.statusText);
+        const cached = getCachedFlags(sanitizedEnvironment);
+        if (cached) {
+          setState({ flags: cached.flags, loading: false });
+          setEnvId(cached.envId);
+          return;
+        }
+
         setState({ flags: [], loading: false });
         return;
       }
@@ -67,11 +120,18 @@ export function useFeatureFlags(
       console.log('[use-feature-flags] fetched flags', flags);
 
       // Store environment_id from first flag (assumes all have same env)
-      if (flags.length > 0 && flags[0].environment_id) {
-        setEnvId(flags[0].environment_id);
-      }
+      const nextEnvId = flags.length > 0 ? flags[0]?.environment_id ?? null : null;
+      setEnvId(nextEnvId);
+      setCachedFlags(sanitizedEnvironment, flags, nextEnvId);
     } catch (err: any) {
       console.error('Error fetching flags:', err.message);
+      const cached = getCachedFlags(sanitizedEnvironment);
+      if (cached) {
+        setState({ flags: cached.flags, loading: false });
+        setEnvId(cached.envId);
+        return;
+      }
+
       setState({ flags: [], loading: false });
     }
   };
@@ -128,7 +188,6 @@ export function useFeatureFlags(
     loading: state.loading,
   };
 }
-
 
 
 

--- a/src/useFeatureFlags.ts
+++ b/src/useFeatureFlags.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { FeatureFlag, featureFlagsAtom } from './store';
 import { useAtom } from 'jotai';
 import { getSupabase, getSupabaseUrl } from './supabaseClient';
+import { isDebugEnabled } from './env';
 const CACHE_KEY_PREFIX = 'use-feature-flags-cache';
 
 
@@ -76,11 +77,13 @@ export function useFeatureFlags(
   const apiKey = passedKey;
 
   useEffect(() => {
-   process.env.DEBUG && console.log(
-      '[use-feature-flags] initializing',
-      `environment: ${sanitizedEnvironment}`,
-      `apiKey provided: ${Boolean(apiKey)}`
-    );
+    if (isDebugEnabled()) {
+      console.log(
+        '[use-feature-flags] initializing',
+        `environment: ${sanitizedEnvironment}`,
+        `apiKey provided: ${Boolean(apiKey)}`
+      );
+    }
   }, [sanitizedEnvironment, apiKey]);
   const supabase = getSupabase();
   const edgeFnUrl = useMemo(() => `${getSupabaseUrl()}/functions/v1/get-feature-flags`, []);
@@ -88,7 +91,9 @@ export function useFeatureFlags(
   const fetchFlags = async () => {
     setState((prev) => ({ ...prev, loading: true }));
 
-    console.log('[use-feature-flags] fetching flags for', sanitizedEnvironment);
+    if (isDebugEnabled()) {
+      console.log('[use-feature-flags] fetching flags for', sanitizedEnvironment);
+    }
 
     try {
       const res = await fetch(edgeFnUrl, {
@@ -116,7 +121,9 @@ export function useFeatureFlags(
 
       const flags = json.flags || [];
       setState({ flags, loading: false });
-      console.log('[use-feature-flags] fetched flags', flags);
+      if (isDebugEnabled()) {
+        console.log('[use-feature-flags] fetched flags', flags);
+      }
 
       // Store environment_id from first flag (assumes all have same env)
       const nextEnvId = flags.length > 0 ? flags[0]?.environment_id ?? null : null;
@@ -180,7 +187,9 @@ export function useFeatureFlags(
   return {
     isActive: (key: string) => {
       const active = state.flags.some((f) => f.key === key && f.enabled === true);
-      process.env.DEBUG && console.log('[use-feature-flags] isActive', key, active);
+      if (isDebugEnabled()) {
+        console.log('[use-feature-flags] isActive', key, active);
+      }
       return active;
     },
     flags: state.flags,


### PR DESCRIPTION
### Motivation
- Prevent the app from losing all feature-flag state during transient Supabase/edge-function outages by serving a recent cached copy.

### Description
- Add browser-safe cache helpers `getCacheKey`, `getCachedFlags`, and `setCachedFlags` that persist a `CachedFlags` payload (flags, `envId`, `updatedAt`) to `localStorage` keyed by environment.
- Persist fetched flags and derived `envId` into the cache after every successful edge-function fetch in `src/useFeatureFlags.ts`.
- When the edge function returns non-OK or a fetch throws, attempt to load and serve cached flags (and cached `envId`) instead of immediately clearing flags.
- Guard cache reads/writes for non-browser contexts and malformed payloads, and log warnings on cache errors.

### Testing
- Ran the package build with `npm run build`, which completed successfully (ESM/CJS/DTS bundles produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10fff60d8832cb20c3346630c5b76)